### PR TITLE
Escaping webhook URL

### DIFF
--- a/discord-notify.sh
+++ b/discord-notify.sh
@@ -87,9 +87,9 @@ messages+=("$message")
 
 count="${#messages[@]}"
 for i in "${!messages[@]}"; do
-	curl -H "Content-Type: application/json" -X POST -d "{\"content\": \"${messages[$i]}\"}" $url
+	curl -H "Content-Type: application/json" -X POST -d "{\"content\": \"${messages[$i]}\"}" "$url"
 	if [ $count -gt 1 ]; then
-		curl -H "Content-Type: application/json" -X POST -d "{\"content\": \"$(( i + 1 ))/$count\"}" $url
+		curl -H "Content-Type: application/json" -X POST -d "{\"content\": \"$(( i + 1 ))/$count\"}" "$url"
 	fi
 done
 


### PR DESCRIPTION
I can't really explain why exactly this is changing, but for my webhook URL executing in bash:

`https://discord.com/api/webhooks/<redacted>/<redacted>DL-KEx79I4enCT6yWmcE9UT_DZ7k-CH`
was being converted to
`https://discord.com/api/webhooks/<redacted>/<redacted>DL-KEx79I4e CT6yWmcE9UT_DZ7k-CH`

which was breaking the curl execution.

The proposed change is to put the url between `"` to avoid any kind of shell expansion. This should not have any side effects.